### PR TITLE
Update Pan Docs link

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@
 			<dl>
 				<dt> <a href="https://www.pastraiser.com/cpu/gameboy/gameboy_opcodes.html">Gameboy Opcodes</a> </dt>
 				<dd> Handy overview of opcode timings &amp; sizes </dd>
-				<dt> <a href="http://bgb.bircd.org/pandocs.htm">The Pandocs</a> </dt>
+				<dt> <a href="https://gbdev.io/pandocs/">The Pandocs</a> </dt>
 				<dd> <em> The </em> introduction to Game Boy hardware </dd>
 				<dt> <a href="https://github.com/Gekkio/mooneye-gb">Mooneye GB</a> </dt>
 				<dd> Well documented set of test ROMs </dd>


### PR DESCRIPTION
The Pan Docs, originally hosted by a number of mirrors (including the BGB mirror you reference), have moved to a continously-updated website within the GB Dev site. This PR updates the link to the new location, which should be easier to navigate and which is frequently updated.